### PR TITLE
Fix magit-topgit-topic-re.

### DIFF
--- a/magit-topgit.el
+++ b/magit-topgit.el
@@ -108,7 +108,7 @@
 (defun magit-start-topgit (&optional input &rest args)
   (apply #'magit-start-process magit-topgit-executable input args))
 
-(defconst magit-topgit-topic-re "^\\(.\\{7\\}\\)\t\\([^ ]+\\) +\\(.*\\)")
+(defconst magit-topgit-topic-re "^\\(.\\{7\\}\\)\t\\([^ \t]+\\)[ \t]+\\(.*\\)")
 
 (defun magit-topgit-read-topic (prompt)
   (magit-completing-read


### PR DESCRIPTION
This patch adds tabulators to the regular expression parsing tg summary
output. It is necessary so that it can parse output like this:

```
        t/c++14/cygthread-run-function  [PATCH] t/c++14/cygthread-run-function
        t/c++14/minimal-changes         [PATCH] t/c++14/minimal-changes
>   D   t/c++14/use-cygthread-run-ldap-cc   [PATCH] t/c++14/use-cygthread-run-ldap-cc
```
